### PR TITLE
Resize images (max 800x418)

### DIFF
--- a/tasks/generate.js
+++ b/tasks/generate.js
@@ -7,6 +7,7 @@ const fs = require('fs').promises
 const { generate: generateBlogPost } = require('./generate-blog-post.js')
 const { generate: generateCommunityMemberCard } = require('./generate-community-member-card-image.js')
 const { copyImages } = require('./copy-images.js')
+const { resizeImages } = require('./resize-images.js')
 const { getIssueDate, getIssueDirectory, getBuildDirectory } = require('./lib/data.js')
 
 const rootDirectory = ospath.join(__dirname, '..')
@@ -30,6 +31,8 @@ if (!issueDate) {
     debug(`Featured community member image generated: ${ospath.relative(rootDirectory, generateCommunityMemberCardResult.outputFile)}`)
     const copyImagesResult = await copyImages(issueDate)
     debug(`Images copied to: ${ospath.relative(rootDirectory, copyImagesResult.destinationDirectory)}`)
+    // resize images
+    resizeImages(copyImagesResult.destinationDirectory, issueDate)
   } catch (e) {
     console.error('Something wrong happened!', e)
   }

--- a/tasks/resize-images.js
+++ b/tasks/resize-images.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const ospath = require('path')
+const { execSync } = require('child_process')
+const fs = require('fs').promises
+const debug = require('debug')('resize-images')
+const { getCommunityMembersData } = require('./lib/data.js')
+
+async function resizeImages(buildImagesDirectory, issueDate) {
+  const communityMemberJson = await getCommunityMembersData(issueDate)
+  const thumbsDirectory = ospath.join(buildImagesDirectory, 'thumbs')
+  await fs.rmdir(thumbsDirectory, { recursive: true })
+  const originalImages = await fs.readdir(buildImagesDirectory)
+  await fs.mkdir(thumbsDirectory)
+  execSync(`"mogrify" "-path" "thumbs/" "-thumbnail" "800x418>" ${originalImages.map(image => `"${image}"`).join(' ')}`, { cwd: buildImagesDirectory })
+  const images = await fs.readdir(thumbsDirectory)
+  for (const image of images) {
+    if (image === communityMemberJson.image) {
+      continue // ignore!
+    }
+    await fs.copyFile(ospath.join(thumbsDirectory, image), ospath.join(buildImagesDirectory, image))
+  }
+  // cleanup
+  await fs.rmdir(thumbsDirectory, { recursive: true })
+}
+
+module.exports = {
+  resizeImages
+}

--- a/tasks/resize-images.js
+++ b/tasks/resize-images.js
@@ -7,6 +7,12 @@ const debug = require('debug')('resize-images')
 const { getCommunityMembersData } = require('./lib/data.js')
 
 async function resizeImages(buildImagesDirectory, issueDate) {
+  try {
+    execSync(`"mogrify" "--version"`)
+  } catch (e) {
+    console.log("Unable to resize images, 'mogrify' command not found. Make sure that ImageMagick is correctly installed: https://imagemagick.org/script/download.php")
+    return
+  }
   const communityMemberJson = await getCommunityMembersData(issueDate)
   const thumbsDirectory = ospath.join(buildImagesDirectory, 'thumbs')
   await fs.rmdir(thumbsDirectory, { recursive: true })


### PR DESCRIPTION
Based on `mogrify` (https://imagemagick.org/script/mogrify.php).

Make sure that ImageMagick is installed on your system: https://imagemagick.org/script/download.php, otherwise, you will get the following output:

```
$ npm run generate 2021-09-11

> twin4j@1.0.0 generate /home/guillaume/workspace/neo4j/twin4j
> node tasks/generate.js "2021-09-11"

Generating Twin4j newsletter 2021-09-11...
/bin/sh: 1: mogrify: not found
Unable to resize images, 'mogrify' command not found. Make sure that ImageMagick is correctly installed: https://imagemagick.org/script/download.php
```